### PR TITLE
Add ability to load/save specified map

### DIFF
--- a/config/config_helper.go
+++ b/config/config_helper.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -40,18 +39,18 @@ func MqttPassword() string {
 	return config.Mqtt.Connection.Authentication.Credentials.Password
 }
 func RotationKeepMaps() int {
-	roationKeepMaps, err := strconv.Atoi(Getenv("ROTATION_KEEP_MAPS", "5"))
+	rotationKeepMaps, err := strconv.Atoi(Getenv("ROTATION_KEEP_MAPS", "5"))
 	if err != nil {
-		roationKeepMaps = 5
+		rotationKeepMaps = 5
 	}
-	return roationKeepMaps
+	return rotationKeepMaps
 }
 
 var valetudoConfig ValetudoConfig
 
 func getValetudoConfig() ValetudoConfig {
 	if (valetudoConfig == ValetudoConfig{}) {
-		configJson, err := ioutil.ReadFile(jsonConfigFile)
+		configJson, err := os.ReadFile(jsonConfigFile)
 		if err != nil {
 			log.Print(err)
 		}

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func loadMap(client mqtt.Client, mapName string) {
 		mapName = currentMap
 	}
 
-	mapFileToLoadMatches, err := filepath.Glob(filepath.Join(maploaderDir, mapName+".tar"))
+	mapFileToLoadMatches, err := filepath.Glob(filepath.Join(maploaderDir, mapName+".tar.gz"))
 	checkAndHandleErrorWithMqtt(err, client)
 
 	publishState(client, "loading_map")

--- a/main.go
+++ b/main.go
@@ -135,10 +135,10 @@ func saveMap(client mqtt.Client, mapName string) {
 	publishState(client, "saving_map")
 	log.Printf("Saving current map as %s\n", mapName)
 
-	err := util.RotateFile(rotationKeepMaps, filepath.Join(maploaderDir, mapName), "tar")
+	err := util.RotateFile(rotationKeepMaps, filepath.Join(maploaderDir, mapName), "tar.gz")
 	checkAndHandleErrorWithMqtt(err, client)
 
-	err = tar.Tar(fmt.Sprintf("%s/%s.tar.gz", maploaderDir, currentMap), robot.CurrentRobot.MapFilesAndFolders()...)
+	err = tar.Tar(fmt.Sprintf("%s/%s.tar.gz", maploaderDir, mapName), robot.CurrentRobot.MapFilesAndFolders()...)
 	checkAndHandleErrorWithMqtt(err, client)
 
 	currentMap = mapName

--- a/main.go
+++ b/main.go
@@ -13,14 +13,18 @@ import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
-const stateTopic string = "valetudo/maploader/status"
-const currentMapTopic string = "valetudo/maploader/map"
-const commandTopic string = currentMapTopic + "/set"
+const (
+	stateTopic      string = "valetudo/maploader/status"
+	currentMapTopic string = "valetudo/maploader/map"
+	saveTopic       string = currentMapTopic + "/save"
+	loadTopic       string = currentMapTopic + "/load"
+	setTopic        string = currentMapTopic + "/set"
+)
 
 var maploaderDir string
 var currentMap string
 
-var roationKeepMaps int
+var rotationKeepMaps int
 
 var messageStateTopicHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
 	log.Printf("Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
@@ -30,16 +34,39 @@ var messageStateTopicHandler mqtt.MessageHandler = func(client mqtt.Client, msg 
 	}
 }
 
-var messageCommandTopicHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
+var messageSaveTopicHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
 	log.Printf("Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
-	changeMap(client, string(msg.Payload()))
+	saveMap(client, string(msg.Payload()))
+}
+
+var messageLoadTopicHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
+	log.Printf("Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
+	loadMap(client, string(msg.Payload()))
+}
+
+var messageSetTopicHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
+	log.Printf("Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
+	saveMap(client, currentMap)
+	loadMap(client, string(msg.Payload()))
 }
 
 var connectHandler mqtt.OnConnectHandler = func(client mqtt.Client) {
 	log.Println("Connected")
 
-	subCommandTopic(client)
-	subCurrentMapTopic(client)
+	subscriptions := []struct {
+		Topic   string
+		Handler mqtt.MessageHandler
+	}{
+		{currentMapTopic, messageStateTopicHandler},
+		{saveTopic, messageSaveTopicHandler},
+		{loadTopic, messageLoadTopicHandler},
+		{setTopic, messageSetTopicHandler},
+	}
+	for _, sub := range subscriptions {
+		token := client.Subscribe(sub.Topic, 1, sub.Handler)
+		token.Wait()
+		log.Printf("Subscribed to topic: %s", sub.Topic)
+	}
 }
 
 var connectLostHandler mqtt.ConnectionLostHandler = func(client mqtt.Client, err error) {
@@ -49,7 +76,7 @@ var connectLostHandler mqtt.ConnectionLostHandler = func(client mqtt.Client, err
 func main() {
 	currentMap = config.Getenv("DEFAULT_MAP_NAME", "main")
 	maploaderDir = config.Getenv("MAPLOADER_DIR", "/data/maploader")
-	roationKeepMaps = config.RotationKeepMaps()
+	rotationKeepMaps = config.RotationKeepMaps()
 
 	util.InitLogging(maploaderDir + "/log")
 	config.InitConfig(config.Getenv("VALETUDO_CONFIG_PATH", "/data/valetudo_config.json"))
@@ -73,16 +100,12 @@ func main() {
 
 	client := mqtt.NewClient(opts)
 	retry := time.NewTicker(5 * time.Second)
-RetryLoop:
-	for {
-		select {
-		case <-retry.C:
-			if token := client.Connect(); token.Wait() && token.Error() != nil {
-				//handle error
-			} else {
-				retry.Stop()
-				break RetryLoop
-			}
+	for range retry.C {
+		if token := client.Connect(); token.Wait() && token.Error() != nil {
+			//handle error
+		} else {
+			retry.Stop()
+			break
 		}
 	}
 	publishState(client, "idle")
@@ -96,65 +119,67 @@ func publishCurrentMap(client mqtt.Client) {
 	token.Wait()
 	time.Sleep(time.Second)
 }
+
 func publishState(client mqtt.Client, status string) {
 	token := client.Publish(stateTopic, 0, true, status)
 	token.Wait()
 	time.Sleep(time.Second)
 }
 
-func subCommandTopic(client mqtt.Client) {
-	topic := commandTopic
-	token := client.Subscribe(topic, 1, messageCommandTopicHandler)
-	token.Wait()
-	log.Printf("Subscribed to topic: %s", topic)
-}
+// Save the current map as the given name
+func saveMap(client mqtt.Client, mapName string) {
+	if mapName == "" {
+		mapName = currentMap
+	}
 
-// Subscribes to the current map topic to load the last map loaded
-func subCurrentMapTopic(client mqtt.Client) {
-	topic := currentMapTopic
-	token := client.Subscribe(topic, 1, messageStateTopicHandler)
-	token.Wait()
-	log.Printf("Subscribed to topic: %s", topic)
-}
+	publishState(client, "saving_map")
+	log.Printf("Saving current map as %s\n", mapName)
 
-// Switches the map and reboots the robot
-func changeMap(client mqtt.Client, newMap string) {
-	publishState(client, "changing_map")
-	log.Printf("Changing map from %s to %s\n", currentMap, newMap)
+	err := util.RotateFile(rotationKeepMaps, filepath.Join(maploaderDir, mapName), "tar")
+	checkAndHandleErrorWithMqtt(err, client)
 
-	err := util.RotateFile(roationKeepMaps, fmt.Sprintf("%s/%s", maploaderDir, currentMap), "tar")
-
-	log.Println("saving current map")
 	err = tar.Tar(fmt.Sprintf("%s/%s.tar.gz", maploaderDir, currentMap), robot.CurrentRobot.MapFilesAndFolders()...)
 	checkAndHandleErrorWithMqtt(err, client)
 
+	currentMap = mapName
+	publishCurrentMap(client)
+	publishState(client, "idle")
+}
+
+// Load the map of the given name
+func loadMap(client mqtt.Client, mapName string) {
+	if mapName == "" {
+		mapName = currentMap
+	}
+
+	mapFileToLoadMatches, err := filepath.Glob(filepath.Join(maploaderDir, mapName+".tar"))
+	checkAndHandleErrorWithMqtt(err, client)
+
+	publishState(client, "loading_map")
+	log.Printf("Attempting to load map %s\n", mapName)
 	log.Println("stopping processes")
 	robot.StopProcesses()
 
 	log.Println("removing current map files")
 	util.RemoveDirContents(robot.CurrentRobot.MapFolders...)
 
-	mapFileToLoadMatches, err := filepath.Glob(fmt.Sprintf("%s/%s.tar*", maploaderDir, newMap))
-	checkAndHandleErrorWithMqtt(err, client)
-
 	if len(mapFileToLoadMatches) == 0 {
-		log.Println("requested map does not exist")
+		log.Println("requested map does not exist, loading blank map")
 	} else {
-		log.Println("restoring map from archive")
+		log.Println("loading map from archive")
 		err = tar.Untar(mapFileToLoadMatches[0], "/")
 		checkAndHandleErrorWithMqtt(err, client)
 	}
 
-	log.Println("map change complete, syncing files")
+	log.Println("map load complete, syncing files")
 	robot.ExcuteCmd("sync")
 
 	log.Println("restarting processes")
 	robot.StartProcesses()
 
-	currentMap = newMap
+	currentMap = mapName
 	publishCurrentMap(client)
 	publishState(client, "idle")
-
 }
 
 func checkAndHandleErrorWithMqtt(err error, client mqtt.Client) {

--- a/robot/processes.go
+++ b/robot/processes.go
@@ -41,16 +41,6 @@ func ExcuteCmd(cmdStr string, cmdArgs ...string) {
 	}
 }
 
-func getRobotHostname() []byte {
-	cmd := exec.Command("uname", "-n")
-	out, err := cmd.Output()
-
-	if err != nil {
-		util.CheckAndHandleError(err)
-	}
-	return out
-}
-
 func startValetudo() {
 	devnull, dnerr := os.OpenFile(os.DevNull, os.O_WRONLY, 0755)
 	if dnerr != nil {

--- a/tar/tar_helper.go
+++ b/tar/tar_helper.go
@@ -12,14 +12,14 @@ func Tar(tarballFilePath string, filePaths ...string) error {
 
 // Use shell command tar to untar into the root file system
 func Untar(tarballFilePath string, target string) error {
-	return tarCommand("xvf", tarballFilePath, "-C", "/")
+	return tarCommand("xvf", tarballFilePath, "-C", target)
 }
 
 // Private methods
 
 func tarCommand(mode string, tarballFilePath string, filePaths ...string) error {
 	app := "tar"
-	args := append([]string{mode, tarballFilePath})
+	args := []string{mode, tarballFilePath}
 	argsFinal := append(args, filePaths...)
 
 	cmd := exec.Command(app, argsFinal...)

--- a/util/file_util.go
+++ b/util/file_util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -11,7 +10,7 @@ import (
 
 func RemoveDirContents(dirNames ...string) error {
 	for _, dirName := range dirNames {
-		dir, err := ioutil.ReadDir(dirName)
+		dir, err := os.ReadDir(dirName)
 		for _, d := range dir {
 			os.RemoveAll(path.Join([]string{dirName, d.Name()}...))
 		}


### PR DESCRIPTION
This is my attempt at implementing the ability to load/save specified maps via MQTT.

It adds new valetudo/maploader/map/load and valetudo/maploader/map/save topics which accept a string payload containing the map name to operate on. An empty map name operates on the current map.

This hasn't been fully tested yet, but I wanted to get the pull request in to get feedback. **Needs to be tested, and documentation added, before merging.**

Some code cleanup (fixed typos, removed old/unused functions) was also done.
