### PR TITLE
Add Dreame Z10 Pro to supported robots

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following models are known to work with the maploader:
 | Model                | binary                     |
 |----------------------|----------------------------|
 | Dreame L10 Pro       | maploader-arm64            |
+| Dreame Z10 Pro       | maploader-arm64            |
 | Dreame F9            | maploader-arm              |
 | Dreame D9 Pro        | maploader-arm              |
 


### PR DESCRIPTION
Works perfectly! Kind of to be expected as it's basically the same robot as the L10, but with an auto empty dock.