### PR TITLE
Add support for Dreame D9 (p2009)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following models are known to work with the maploader:
 | Dreame L10 Pro       | maploader-arm64            |
 | Dreame Z10 Pro       | maploader-arm64            |
 | Dreame F9            | maploader-arm              |
+| Dreame D9            | maploader-arm              |
 | Dreame D9 Pro        | maploader-arm              |
 
 If your Dreame robot is not listed here, you need to find out the arch of your robot (e.g. with ```uname -m```, where ```aarch64``` -> ...-arm64 binary).

--- a/robot/robot_models.go
+++ b/robot/robot_models.go
@@ -9,6 +9,10 @@ var robots []Robot = []Robot{
 		MapFolders:       []string{"/data/log/ri/", "/data/DivideMap"},
 		mapFiles:         []string{"/data/config/ava/mult_map.json", "/data/log/map_info.bin", "/data/log/slam.db"},
 		restartProcesses: []Process{MiioClientProcess, AvaProcess}},
+	{model: "p2009", // Dreame D9
+		MapFolders:       []string{"/data/ri", "/data/map", "/data/DivideMap", "/data/DivideDebug"},
+		mapFiles:         []string{"/data/config/ava/mult_map.json", "/data/log/map_info.bin"},
+		restartProcesses: []Process{MiioClientProcess, AvaProcess}},
 	{model: "p2187", // Dreame D9 Pro
 		MapFolders:       []string{"/data/ri", "/data/map", "/data/DivideMap", "/data/DivideDebug"},
 		mapFiles:         []string{"/data/config/ava/mult_map.json", "/data/log/map_info.bin"},


### PR DESCRIPTION
Dreame D9 is almost identical to Dreame D9 Pro, which is already supported - the only difference is suction pressure. Tested and works.