### PR TITLE
Allow multiple maploaders on one MQTT broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,16 @@ After the map change, Valetudo will be restarted and will not be reachable for s
 I am using this with Home Assistant, where I trigger the map change as part of an automation and move the robot to the other zone. It can then be operated on the new map after the reboot.
 
 ## MQTT Topics
-* Current map topic: ```valetudo/{identifier}/maploader/map```
-* Command topic: ```valetudo/{identifier}/maploader/map/set```
-* Save map topic: ```valetudo/{identifier}/maploader/map/save```
-* Load map topic: ```valetudo/{identifier}/maploader/map/load```
-* Maploader state topic: ```valetudo/{identifier}/maploader/status```
+
+| Topic                                      | Publisher    | Payload   | Description                                                                                                                                                                                                          |
+|--------------------------------------------|--------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `valetudo/{identifier}/maploader/map`      | Robot + Home | Map name  | Maploader publishes the current map name to this topic after a map switch.<br/><br/>Can be used to set the current map name without changing the active map.                                                         |
+| `valetudo/{identifier}/maploader/map/set`  | Home         | Map name  | Stores the active map and switches to the given map.<br/><br/>A backup of the current map file is made before the active map is stored.<br/><br/>If no map is stored under the given map name a blank map is loaded. |
+| `valetudo/{identifier}/maploader/map/save` | Home         | Map name  | Saves the active map under the given name and switches to that map.<br/><br/>A backup of the map file is made before it is overwritten.                                                                              |
+| `valetudo/{identifier}/maploader/map/load` | Home         | Map name  | Switches to the given map without storing the active map.<br/><br/>If no map is stored under the given map name a blank map is loaded.                                                                               |
+| `valetudo/{identifier}/maploader/status`   | Robot        | see below | Maploader publishes its current status to this topic.                                                                                                                                                                |
 
 The identifier is set in the MQTT settings in Valetudo.
-
-The payload in the map topics simply is the string determining the map name.
-
-Load and Save may be used for backup functionality, i.e. saving a map under a different name.
 
 The maploader status can change to the following value:
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ After the map change, Valetudo will be restarted and will not be reachable for s
 I am using this with Home Assistant, where I trigger the map change as part of an automation and move the robot to the other zone. It can then be operated on the new map after the reboot.
 
 ## MQTT Topics
-* Current map topic: ```valetudo/maploader/map```
-* Command topic: ```valetudo/maploader/map/set```
-* Save map topic: ```valetudo/maploader/map/save```
-* Load map topic: ```valetudo/maploader/map/load```
-* Maploader state topic: ```valetudo/maploader/status```
+* Current map topic: ```valetudo/{identifier}/maploader/map```
+* Command topic: ```valetudo/{identifier}/maploader/map/set```
+* Save map topic: ```valetudo/{identifier}/maploader/map/save```
+* Load map topic: ```valetudo/{identifier}/maploader/map/load```
+* Maploader state topic: ```valetudo/{identifier}/maploader/status```
+
+The identifier is set in the MQTT settings in Valetudo.
 
 The payload in the map topics simply is the string determining the map name.
 
@@ -52,11 +54,11 @@ This project does not support Home Assistant auto discovery as I am using the se
 ```
 mqtt:
   sensor:
-    - state_topic: valetudo/maploader/status
+    - state_topic: valetudo/foo/maploader/status
       name: "vacuum_maploader_status"
   select:
-    - command_topic: valetudo/maploader/map/set
-      state_topic: valetudo/maploader/map
+    - command_topic: valetudo/foo/maploader/map/set
+      state_topic: valetudo/foo/maploader/map
       name: "vacuum_maploader_map"
       options:
         - "main"

--- a/config/config_helper.go
+++ b/config/config_helper.go
@@ -46,6 +46,10 @@ func MqttTLSCA() string {
 	config := getValetudoConfig()
 	return config.Mqtt.Connection.TLS.Ca
 }
+func MqttIdentifier() string {
+	config := getValetudoConfig()
+	return config.Mqtt.Identity.Identifier
+}
 
 func RotationKeepMaps() int {
 	rotationKeepMaps, err := strconv.Atoi(Getenv("ROTATION_KEEP_MAPS", "5"))

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ var currentMap string
 
 var rotationKeepMaps int
 
-var messageStateTopicHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
+var messageCurrentMapTopicHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
 	log.Printf("Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
 	if string(msg.Payload()) != currentMap {
 		log.Printf("Loaded current map from status topic")
@@ -62,7 +62,7 @@ var connectHandler mqtt.OnConnectHandler = func(client mqtt.Client) {
 		Topic   string
 		Handler mqtt.MessageHandler
 	}{
-		{formatMqttTopic(currentMapTopic), messageStateTopicHandler},
+		{formatMqttTopic(currentMapTopic), messageCurrentMapTopicHandler},
 		{formatMqttTopic(saveTopic), messageSaveTopicHandler},
 		{formatMqttTopic(loadTopic), messageLoadTopicHandler},
 		{formatMqttTopic(setTopic), messageSetTopicHandler},


### PR DESCRIPTION
Maploader currently uses static MQTT topics like `valetudo/maploader/map/set`. Since those must be unique per MQTT broker, two maploaders using the same MQTT broker would cause a conflict.

Valetudo itself solves this problem by including an identifier in the MQTT topic, like `valetudo/top_floor_vacuum/BatteryStateAttribute/level` (with `top_floor_vacuum` being the identifier here).

This PR adds this identifier to the maploader topics as well, so that they become for example `valetudo/top_floor_vacuum/maploader/map/set`.

**This is a breaking change**, there is no compatibility with the old topics. If you are using Home Assistant automations, you have to add the identifier to the MQTT topics there.

This PR also adds the identifier to the MQTT connection client ID because it must also be unique per broker.